### PR TITLE
add error middleware

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,19 +15,26 @@ const PROD = NODE_ENV === 'production'
 
 const app = express()
 
+// disable headers
 app
   .disable('x-powered-by')
   .disable('etag')
 
+// mount vendor middleware
 app
   .use(morgan(!PROD ? 'dev' : 'combined'))
   .use(compression())
   .use(helmet())
   .use(jsonParser())
 
+// mount routers
 app.use('/', routers.mainRouter)
 app.use('/users', routers.userRouter)
 
 app.get('/secret', middleware.requireAuth, (req, res) => res.send(req.user))
+
+// mount error middleware
+app.use(middleware.notFound)
+app.use(middleware.errorHandler)
 
 app.listen(PORT || 3000)

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,0 +1,17 @@
+export default (err, req, res, next) => {
+  const status = err.status || 500
+  const message = err.message || 'Something broke ):'
+  const body = { status, message, error: true }
+
+  const isServerError = status <= 500
+
+  if (isServerError) console.error(err)
+
+  if (isServerError && process.NODE_ENV !== 'production') {
+    return res.status(status).json({ ...body, stack: err.stack })
+  }
+
+  res.send(status).json(body)
+  
+  res.status(status)
+}

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -1,1 +1,3 @@
 export { default as requireAuth } from './requireAuth'
+export { default as errorHandler } from './errorHandler'
+export { default as notFound } from './notFound'

--- a/src/middleware/notFound.js
+++ b/src/middleware/notFound.js
@@ -1,0 +1,5 @@
+export default (req, res, next) => {
+  const err = new Error('Not found')
+  err.status = 404
+  next(err)
+}


### PR DESCRIPTION
To handle all API errors in a nice format:

```js
{
  "error": true,
  "status": ERROR_STATUS,
  "message": ERROR_MESSAGE,
  "stack": ERROR_STACK
}
```